### PR TITLE
advanced config settings for docker-compose

### DIFF
--- a/example/advanced/README.md
+++ b/example/advanced/README.md
@@ -1,0 +1,7 @@
+# Advanced Config Example
+
+This example demonstrates ways to customize the docker-compose file to create your own environment.
+
+1. Custom bitcoin.conf
+2. JSON-RPC Support
+3. Custom datadir path for volume

--- a/example/advanced/bitcoin.conf
+++ b/example/advanced/bitcoin.conf
@@ -1,0 +1,23 @@
+dbcache=4000
+txindex=1
+
+# [rpc]
+# Accept command line and JSON-RPC commands.
+server=1
+# Username for JSON-RPC connections
+rpcuser=root
+# Password for JSON-RPC connections
+rpcpassword=bitcoin
+rpcallowip=0.0.0.0/0
+
+printtoconsole=1
+
+# [wallet]
+# Do not load the wallet and disable wallet RPC calls.
+disablewallet=1
+
+zmqpubhashtx=tcp://127.0.0.1:28332
+zmqpubhashblock=tcp://127.0.0.1:28332
+
+# Rpc work queue increase
+rpcworkqueue=512

--- a/example/advanced/docker-compose.yml
+++ b/example/advanced/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3"
+services:
+  bitcoind:
+    image: zquestz/bitcoin-abc
+    # specify additional command line arguments here
+    command: bitcoind
+    healthcheck:
+      test: ["CMD", "/entrypoint.sh", "bitcoin-cli", "getinfo"]
+    ports:
+      # change to 18333 if running testnet
+      - "8333:8333"
+      # JSON-RPC
+      - "8332:8332"
+    volumes:
+      # using a custom path for data dir
+      - /mnt/volume-sfo2-03/data:/data
+      # using a custom path for custom bitcoin.conf
+      - ./bitcoin.conf:/data/bitcoin.conf
+    networks:
+      - bitcoin
+  bitcoin-cli:
+    image: zquestz/bitcoin-abc
+    entrypoint: ["/entrypoint.sh", "bitcoin-cli"]
+    command: ""
+    depends_on:
+      - bitcoind
+    network_mode: service:bitcoind
+    volumes:
+      # using a custom path for custom bitcoin.conf
+      - ./bitcoin.conf:/data/bitcoin.conf
+
+networks:
+  bitcoin:

--- a/example/advanced/docker-compose.yml
+++ b/example/advanced/docker-compose.yml
@@ -11,9 +11,11 @@ services:
       - "8333:8333"
       # JSON-RPC
       - "8332:8332"
+      # ZMQ
+      - "28332:28332"
     volumes:
       # using a custom path for data dir
-      - /mnt/volume-sfo2-03/data:/data
+      - ./data:/data
       # using a custom path for custom bitcoin.conf
       - ./bitcoin.conf:/data/bitcoin.conf
     networks:


### PR DESCRIPTION
I've added an additional docker-compose example for building a custom node, such as supporting JSON-RPC, custom bitcoin.conf, and custom volume path.

This is the config I'm using at the moment but please let me know if there's a better way, or if the additional example is not necessary.